### PR TITLE
Change page title to "Avocado Testing Framework"

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Avocado - Automated Testing Framework">
     <meta name="author" content="">
 
-    <title>Avocado - Testing made easier</title>
+    <title>Avocado Testing Framework</title>
 
     <!-- Bootstrap Core CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">


### PR DESCRIPTION
It was "Avocado - Testing made easier", which IMO is
not the best slogan for the kind of framework we provide
today.