### PR TITLE
Fix link to low-hanging-fruit

### DIFF
--- a/contrib.html
+++ b/contrib.html
@@ -81,7 +81,7 @@
                 <p>If you want to start hacking and contributing right away, check out the following resources:</p>
                 <p><strong>Contribution Ideas</strong>
                 <br><a
-                href="https://trello.com/search?q=list%3A%22Short%20Term%20Backlog%22%20%23low-hanging-fruit%20is%3Aopen">Trello - low hanging fruit tasks</a>
+                href="https://trello.com/b/WbqPNl2S/avocado?menu=filter&filter=label:low-hanging-fruit">Trello - low hanging fruit tasks</a>
                 </p>
                 <p><strong>Contribution and Community Guide</strong>
                 <br><a href="http://avocado-framework.readthedocs.org/en/latest/ContributionGuide.html">http://avocado-framework.readthedocs.org/en/latest/ContributionGuide.html</a>


### PR DESCRIPTION
The low-hanging-fruit actually shows $users's cards with this label,
which requires user to be logged-in and it's not showing Avocado
low-hanging-fruit cards but all cards that user has access to (so none
if he does not have Avocado board in his borads).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>