### PR TITLE
Removed Trello links

### DIFF
--- a/contrib.html
+++ b/contrib.html
@@ -81,7 +81,7 @@
                 <p>If you want to start hacking and contributing right away, check out the following resources:</p>
                 <p><strong>Contribution Ideas</strong>
                 <br><a
-                href="https://trello.com/b/WbqPNl2S/avocado?menu=filter&filter=label:low-hanging-fruit">Trello - low hanging fruit tasks</a>
+                href="https://github.com/avocado-framework/avocado/issues?q=is%3Aopen+is%3Aissue+label%3Alow-hanging-fruit">GitHub - low hanging fruit tasks</a>
                 </p>
                 <p><strong>Contribution and Community Guide</strong>
                 <br><a href="http://avocado-framework.readthedocs.org/en/latest/ContributionGuide.html">http://avocado-framework.readthedocs.org/en/latest/ContributionGuide.html</a>

--- a/index.html
+++ b/index.html
@@ -94,7 +94,6 @@
                     <strong><a href="https://www.redhat.com/mailman/listinfo/avocado-devel">Mailing list</a></strong>
                     <br><strong><a href="http://avocado-framework.readthedocs.org">Read the docs</a></strong>
                     <br><strong><a href="irc://irc.oftc.net/#avocado">IRC</a></strong>
-                    <br><strong><a href="https://trello.com/b/WbqPNl2S/avocado">Trello</a></strong>
                     <br><strong><a href="https://github.com/avocado-framework/avocado">Github</a></strong>
                     <br><strong><a href="https://plus.google.com/+Avocado-frameworkGithubIo/posts">Google+</a></strong>
                 </address>


### PR DESCRIPTION
During our Avocado Summit we migrated Trello cards to GH issues.  This
PR remove Trello links.

Signed-off-by: Beraldo Leal <bleal@redhat.com>