### PR TITLE
Add reference to PyPI

### DIFF
--- a/download.html
+++ b/download.html
@@ -83,6 +83,9 @@
                 <p><strong>Github Releases</strong>
                 <br><a href="https://github.com/avocado-framework/avocado/releases">https://github.com/avocado-framework/avocado/releases</a>
                 </p>
+		<p><strong>Python package on PyPI</strong>
+		<br><a href="https://pypi.org/project/avocado-framework/">https://pypi.org/project/avocado-framework/</a>
+		</p>
                 <p><strong>DNF repository for Fedora</strong>
                 <br><a href="https://avocado-project.org/data/repos/avocado-fedora.repo">https://avocado-project.org/data/repos/avocado-fedora.repo</a>
                 </p>


### PR DESCRIPTION
As per User's Guide "Avocado is primarily written in Python, so a standard Python installation is possible and often preferable. You can also install from your distro repository, if available."

Therefore, also reference here Python package on top to give it
some priority.