### PR TITLE
download: provide correct instructions for Fedora

### DIFF
--- a/download.html
+++ b/download.html
@@ -86,8 +86,9 @@
 		<p><strong>Python package on PyPI</strong>
 		<br><a href="https://pypi.org/project/avocado-framework/">https://pypi.org/project/avocado-framework/</a>
 		</p>
-                <p><strong>DNF repository for Fedora</strong>
-                <br><a href="https://avocado-project.org/data/repos/avocado-fedora.repo">https://avocado-project.org/data/repos/avocado-fedora.repo</a>
+                <p><strong>Module for Fedora</strong>
+                  <br><pre># dnf module enable avocado:latest
+# dnf module install avocado</pre>
                 </p>
                 <p><strong>YUM repository for Enterprise Linux</strong>
                 <br><a href="https://avocado-project.org/data/repos/avocado-el.repo">https://avocado-project.org/data/repos/avocado-el.repo</a>


### PR DESCRIPTION
The YUM repo currently pointed to does not exist for current Fedora 34 releases.