### PR TITLE
Add GitHub Actions and update download.html

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: check HTML
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.0.8
+        with:
+          args: --verbose --no-progress *.html
+
+      - name: HTML5 Validator
+        uses: Cyb3r-Jak3/html5validator-action@v0.6.1
+        with:
+          # Path of the files to test
+          root: ./
+          # Checks css as well
+          css: true

--- a/contrib.html
+++ b/contrib.html
@@ -97,7 +97,7 @@
             <div class="row">
                 <div class="col-lg-12">
                     <hr>
-                    <p>Copyright © 2014-2020 Red Hat Inc. and Avocado Community Contributors</p>
+                    <p>Copyright © 2014-2021 Red Hat Inc. and Avocado Community Contributors</p>
                 </div>
             </div>
             <!-- /.row -->

--- a/download.html
+++ b/download.html
@@ -79,26 +79,29 @@
             <div class="col-sm-8">
             <h2>Download Avocado</h2>
                 <p>Get yourself some fresh Avocado</p>
-        <hr>
-                <p><strong>Github Releases</strong>
-                <br><a href="https://github.com/avocado-framework/avocado/releases">https://github.com/avocado-framework/avocado/releases</a>
+                <hr>
+                <p>
+                Avocado code can be found at <a href="https://github.com/avocado-framework/avocado/">https://github.com/avocado-framework/avocado/</a>
+                <br>For detailed instructions and how to install from source, please check our <a href="https://avocado-framework.readthedocs.io/en/latest/guides/user/chapters/installing.html">documentation</a>.</p>
+                <br>
+                <p><strong>Python package on PyPI</strong>
+                <br>You can install the package from PyPI:
+                <br><pre>$ pip3 install avocado-framework</pre>
+                More information at <a href="https://pypi.org/project/avocado-framework/">https://pypi.org/project/avocado-framework/</a>
                 </p>
-		<p><strong>Python package on PyPI</strong>
-		<br><a href="https://pypi.org/project/avocado-framework/">https://pypi.org/project/avocado-framework/</a>
-		</p>
+                <p>Also, check out for the avocado plugins distributed on PyPI <a href="https://pypi.org/search/?q=avocado-framework-plugin">https://pypi.org/search/?q=avocado-framework-plugin</a>
+                </p>
+                <br>
                 <p><strong>Module for Fedora</strong>
+                <br>You only need to enable the module avocado:latest and you'll get avocado updates in the future:
                   <br><pre># dnf module enable avocado:latest
 # dnf module install avocado</pre>
                 </p>
+                <br>
                 <p><strong>YUM repository for Enterprise Linux</strong>
-                <br><a href="https://avocado-project.org/data/repos/avocado-el.repo">https://avocado-project.org/data/repos/avocado-el.repo</a>
+                <br>Get the repository file from <a href="https://avocado-project.org/data/repos/avocado-el.repo">https://avocado-project.org/data/repos/avocado-el.repo</a>
                 </p>
-                <p><strong>PPA for Ubuntu</strong>
-                <br><a href="https://launchpad.net/~lmr/+archive/ubuntu/avocado">https://launchpad.net/~lmr/+archive/ubuntu/avocado</a>
-                </p>
-                <p>For detailed instructions, please check our
-                <a
-                href="https://avocado-framework.readthedocs.io/en/latest/guides/user/chapters/installing.html">documentation</a>.</p>
+
             </div>
         </div>
 

--- a/download.html
+++ b/download.html
@@ -110,7 +110,7 @@
             <div class="row">
                 <div class="col-lg-12">
                     <hr>
-                    <p>Copyright © 2014-2020 Red Hat Inc. and Avocado Community Contributors</p>
+                    <p>Copyright © 2014-2021 Red Hat Inc. and Avocado Community Contributors</p>
                 </div>
             </div>
             <!-- /.row -->

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
             <div class="row">
                 <div class="col-lg-12">
                     <hr>
-                    <p>Copyright © 2014-2020 Red Hat Inc. and Avocado Community Contributors</p>
+                    <p>Copyright © 2014-2021 Red Hat Inc. and Avocado Community Contributors</p>
                     <p><a href="https://www.flickr.com/photos/sara_joachim/2473587957">Avocado Tree Picture</a>
                     (background) by Joachim Huber, CC BY-SA 2.0.</p>
                     </p>


### PR DESCRIPTION
Add GitHub Actions to check the HTML (links and format) and CSS. We have some problems to solve but they're not new and I'm not planning to fix them as part of this PR. This closes https://github.com/avocado-framework/avocado-framework.github.io/issues/20
The resulting GHA can be seen at https://github.com/ana/avocado-framework.github.io/actions

Update download.html:  Reword/reformat the page so it's easier to read. Add and remove some bits of information. 

Update the footer to include 2021 in the copyright.

