### PR TITLE
Site with autils information

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,63 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: main
+      - name: Clone autils repo
+        uses: actions/checkout@v3
+        with:
+          repository: avocado-framework/autils
+          path: resources/autils
+          ref: main
+      - name: Copy autils metadate to _data dir
+        run: cp -r resources/autils/metadata/autils/* main/_data/autils/
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: main/
+          destination: main/_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: main/_site/
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site
+_data/autils/

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,5 +1,6 @@
 <h3><a href="installation.html">Installation</a></h3>
 <h3><a href="quickguide.html">Quick Guide</a></h3>
+<h3><a href="utils.html">Utility Libraries</a></h3>
 
 
 <br/>

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}" media="screen" type="text/css">
+    <link rel="stylesheet" href="{{ '/assets/css/print.css' | relative_url }}" media="print" type="text/css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.12.1/css/jquery.dataTables.css" type="text/css">
+
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <![endif]-->
+
+
+  </head>
+
+  <body>
+    <header>
+      <div class="inner">
+        <a href="{{ '/' | absolute_url }}">
+          <h1>{{ site.title | default: site.github.repository_name }}</h1>
+        </a>
+        <h2>{{ site.description | default: site.github.project_tagline }}</h2>
+          <a href="{{ site.github.repository_url }}" class="button"><small>View project on</small> GitHub</a>
+      </div>
+    </header>
+
+    <div id="content-wrapper">
+      <div class="inner clearfix">
+        <section id="main-content">
+          {{ content }}
+        </section>
+
+      </div>
+    </div>
+
+    <footer>
+      {% if site.github.is_project_page %}
+      <p class="repo-owner"><a href="{{ site.github.repository_url }}">{{ site.github.repository_name }}</a> is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a>.</p>
+      {% endif %}
+
+      <p>Copyright © 2014-2022 Red Hat Inc. and Avocado Community Contributors<br />
+      Background <a href="https://www.flickr.com/photos/sara_joachim/2473587957">Avocado Tree Picture</a> by Joachim Huber, CC BY-SA 2.0.</p>
+    </footer>
+
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.js"></script>
+<script>
+$(document).ready(function () {
+$("#utils-table").DataTable();
+});
+</script>
+  </body>
+</html>

--- a/utils.md
+++ b/utils.md
@@ -1,0 +1,64 @@
+---
+layout: utils
+---
+
+# Utility Libraries
+
+<table id="utils-table">
+  <thead>
+  <tr class="header">
+  <th>Name/Description</th>
+  <th>Category</th>
+  <th>Maintainer</th>
+  <th>Supported Platforms</th>
+  <th>tests</th>
+  <th>remote</th>
+  </tr>
+  </thead>
+
+  <tbody>
+  {% for util_dir_hash in site.data.autils %}
+      {% assign util_dir = util_dir_hash[1] %}
+      {% for util_hash in util_dir %}
+          {% assign util = util_hash[1] %}
+          <tr>
+          <td>
+                <strong markdown="spawn">{{util.name}}</strong>
+                <p markdown="spawn">{{util.description}}</p>
+          </td>
+          <td>
+                <ul>
+                {% for category in util.categories %}
+                   <li markdown="span">{{category}}</li>
+                {% endfor %}
+                </ul>
+          </td>
+          <td>
+                <ul>
+                {% for maintainer in util.maintainers %}
+                   <li markdown="span">{{maintainer["name"]}}, {{maintainer["email"]}}</li>
+                {% endfor %}
+                </ul>
+          </td>
+          <td>
+                <ul>
+                {% for platform in util.supported_platforms %}
+                   <li markdown="span">{{platform}}</li>
+                {% endfor %}
+                </ul>
+          </td>
+          <td>
+                <ul>
+                {% for test in util.tests %}
+                   <li markdown="span">{{test}}</li>
+                {% endfor %}
+                </ul>
+          </td>
+          <td markdown="span">{{util.remote}}</td>
+          </tr>
+      {% endfor %}
+  {% endfor %}
+  </tbody>
+</table>
+
+


### PR DESCRIPTION
This PR will add autils page with list of supported utilities and
their information. This list is based on metadata from
https://github.com/avocado-framework/autils/tree/main/metadata/autils

For deploying the GitHub pages with data from https://github.com/avocado-framework/autils the new GitHub action is used. When this PR will be merged, we have to change GitHub pages deployment from standard to actions.

You can see the result of GitHub action in https://github.com/richtja/avocado-framework.github.io/actions/runs/5142371714 and the page in https://richtja.github.io/avocado-framework.github.io/utils.html.

Reference: https://github.com/avocado-framework/autils/issues/6
Signed-off-by: Jan Richter <jarichte@redhat.com>
Signed-off-by: Beraldo Leal <bleal@redhat.com>