### PR TITLE
Workflow Version Update

### DIFF
--- a/.github/workflows/jekyll-gh-pages-avatar.yml
+++ b/.github/workflows/jekyll-gh-pages-avatar.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: main
 
       - name: Clone autils repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: avocado-framework/aautils
           path: resources/autils
@@ -48,7 +48,7 @@ jobs:
         run: cp -r resources/autils/metadata/**/*.yml main/_data/autils/
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -62,7 +62,7 @@ jobs:
         run: python main/scripts/deployavatar.py
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
@@ -71,7 +71,7 @@ jobs:
           destination: main/_site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: main/_site/
 
@@ -85,4 +85,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updated workflow to use new required version of
actions/upload-artifact - v3 has been depreciated and new version is v4

Reference:      https://github.com/avocado-framework/avocado-framework.github.io/actions/runs/15706917272