### PR TITLE
Workflow Directory Creation

### DIFF
--- a/.github/workflows/jekyll-gh-pages-avatar.yml
+++ b/.github/workflows/jekyll-gh-pages-avatar.yml
@@ -41,11 +41,10 @@ jobs:
       - name: List files in autils directory
         run: ls -R resources/autils/metadata/
 
-      - name: Copy autils metadata to _data dir
-        run: cp -r resources/autils/metadata/* main/_data/autils/
-
-      - name: Copy YAML files from autils
-        run: cp -r resources/autils/metadata/**/*.yml main/_data/autils/
+      - name: Create data directory and copy autils metadata
+        run: |
+          mkdir -p main/_data/autils/
+          cp -r resources/autils/metadata/* main/_data/autils/
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Ensure data directory exists before copy

The build process was failing because the `cp` command could not find its destination directory.

This change adds a `mkdir -p` step to explicitly create the directory, making the workflow more robust and independent of the repository's file structure.