### PR TITLE
Fix mergefiles.py to recursively process subdirectories

### DIFF
--- a/scripts/mergefiles.py
+++ b/scripts/mergefiles.py
@@ -1,3 +1,4 @@
+import glob
 import os
 
 import yaml
@@ -6,21 +7,27 @@ import yaml
 def merge_yaml_files(directory, output_file):
     merged_data = []  # Initialize an empty list to hold merged data
 
-    # Iterate over all files in the directory
-    for filename in sorted(os.listdir(directory)):
-        if filename.endswith(".yml") or filename.endswith(".yaml"):
-            file_path = os.path.join(directory, filename)
-            with open(file_path, "r") as file:
-                # Load the YAML data while preserving order
-                data = yaml.load(file, Loader=yaml.SafeLoader)  # Use SafeLoader
+    # Find all YAML files recursively in subdirectories
 
-                # Check if the loaded data is a dictionary
-                if isinstance(data, dict):
-                    merged_data.append(data)  # Append the dictionary to merged_data
-                else:
-                    print(
-                        f"Warning: The content of {filename} is not a dictionary. Skipping."
-                    )
+    yaml_files = glob.glob(os.path.join(directory, "**", "*.yml"), recursive=True)
+    yaml_files.extend(
+        glob.glob(os.path.join(directory, "**", "*.yaml"), recursive=True)
+    )
+
+    # Process each YAML file found
+    for file_path in sorted(yaml_files):
+        filename = os.path.basename(file_path)
+        with open(file_path, "r") as file:
+            # Load the YAML data while preserving order
+            data = yaml.load(file, Loader=yaml.SafeLoader)  # Use SafeLoader
+
+            # Check if the loaded data is a dictionary
+            if isinstance(data, dict):
+                merged_data.append(data)  # Append the dictionary to merged_data
+            else:
+                print(
+                    f"Warning: The content of {filename} is not a dictionary. Skipping."
+                )
 
     # Write the merged data to the output YAML file
     with open(output_file, "w") as outfile:


### PR DESCRIPTION
- Replace os.listdir() with glob.glob() to enable recursive directory traversal
- Use glob patterns with '**' and recursive=True to find YAML files in nested subdirectories
- Update file processing logic to handle full file paths instead of just filenames
- Use os.path.basename() to extract filename for warning messages

This fix allows the merge script to properly discover and process YAML files located in subdirectories rather than being limited to the immediate directory, making it more flexible for complex directory structures.

Fixes the script's ability to merge YAML configuration files from nested module directories in the website's data structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The script now automatically finds and merges YAML files from all subdirectories, not just the top-level directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->